### PR TITLE
Official improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
         return f.read()
 
 setup(name='ttide',
-      version='0.3.4',
+      version='0.3.5',
       description='Python distribution of the MatLab package TTide.',
       long_description=readme(),
       url='https://github.com/moflaher/ttide_py',

--- a/ttide/base.py
+++ b/ttide/base.py
@@ -1,5 +1,13 @@
+import sys
+import io
 from . import t_utils as tu
 from .t_predic import t_predic
+
+# file object depending on Python version
+if sys.version_info[0] < 3:
+    FILE_OBJ = file  # Python 2
+else:
+    FILE_OBJ = io.IOBase  # Python 3
 
 
 class TTideCon(dict):
@@ -38,7 +46,7 @@ class TTideCon(dict):
             
         if to_file is None:
             return outstr
-        elif isinstance(to_file, file):
+        elif isinstance(to_file, FILE_OBJ):
             to_file.write(outstr)
         else:
             with open(to_file, 'w') as fl:
@@ -48,7 +56,7 @@ class TTideCon(dict):
         outstr = tu.classic_style(self)
         if to_file is None:
             return outstr
-        elif isinstance(to_file, file):
+        elif isinstance(to_file, FILE_OBJ):
             to_file.write(outstr)
         else:
             with open(to_file, 'w') as fl:

--- a/ttide/t_getconsts.py
+++ b/ttide/t_getconsts.py
@@ -78,10 +78,11 @@ def t_getconsts(ctime):
         ii = np.isfinite(const['ishallow'])
         const['freq'][~ii] = np.dot(const['doodson'][~ii, :], ader) / 24
 
+        shallow_m1 = const['ishallow'].astype(int) -1
+        iname_m1 = shallow['iname'].astype(int) -1
+        range_cache = {n:np.arange(n) for n in range(const['nshallow'].max()+1)}
         for k in np.flatnonzero(ii):
-            ik = ((const['ishallow'][k] - 1 +
-                   np.array(range(0, const['nshallow'][k]))).astype(int))
-            const['freq'][k] = np.dot(const['freq'][shallow['iname'][ik] - 1],
-                                      shallow['coef'][ik])
+            ik = shallow_m1[k] + range_cache[const['nshallow'][k]]
+            const['freq'][k] = const['freq'][iname_m1[ik]].dot(shallow['coef'][ik])
 
     return const, sat, shallow

--- a/ttide/t_getconsts.py
+++ b/ttide/t_getconsts.py
@@ -3,7 +3,7 @@ import numpy as np
 import copy
 from .t_astron import t_astron
 import os.path as path
-from scipy.io.netcdf import netcdf_file as nopen
+from scipy.io import netcdf_file as nopen
 
 _base_dir = path.join(path.dirname(__file__), 'data')
 has_const = path.exists(path.join(_base_dir, 't_constituents_const.nc'))

--- a/ttide/t_predic.py
+++ b/ttide/t_predic.py
@@ -60,8 +60,7 @@ def t_predic(t_time, names, freq, tidecon,
         I = snr > synth
         if not any(I):
             print('No predictions with this SNR')
-            yout = np.nan + np.zeros(shape=(t_time.shape, t_time.shape),
-                                     dtype='float64')
+            yout = np.nan + np.zeros_like(t_time, dtype='float64')
             return yout
         tidecon = tidecon[I, :]
         names = names[I]

--- a/ttide/t_predic.py
+++ b/ttide/t_predic.py
@@ -48,7 +48,7 @@ def t_predic(t_time, names, freq, tidecon,
     """
 
     longseries = 0  # Currently only timeseries <18.6 years are supported.
-    if t_time.dtype.name.startswith('datetime64') or t_time.dtype is np.dtype("O"):
+    if t_time.dtype.name.startswith('datetime64') or t_time.dtype == np.dtype("O"):
         t_time = tm.date2num(t_time)
 
     t_time = t_time.reshape(-1, 1)

--- a/ttide/t_tide.py
+++ b/ttide/t_tide.py
@@ -292,7 +292,7 @@ def t_tide(xin, dt=1, stime=None, lat=None,
                             np.cos(2 * pi * np.outer(t, fu)),
                             np.sin(2 * pi * np.outer(t, fu))])
 
-        coef = np.linalg.lstsq(tc[gd, :], xin[gd])[0].T
+        coef = np.linalg.lstsq(tc[gd, :], xin[gd], rcond=None)[0].T
 
         # z0 a+ and a- amplitudes
         z0 = coef[0]
@@ -342,7 +342,7 @@ def t_tide(xin, dt=1, stime=None, lat=None,
                                np.sin(2 * pi * np.outer(tslice, fu))])
                 rhs = rhs + np.dot(E.T, xin[(gd[(j1 - 1):j2] - 1)])
                 lhs = lhs + np.dot(E.T, E)
-        coef = np.linalg.lstsq(lhs, rhs)[0].T
+        coef = np.linalg.lstsq(lhs, rhs, rcond=None)[0].T
 
         # z0 a+ and a- amplitudes
         z0 = coef[0]

--- a/ttide/t_tide.py
+++ b/ttide/t_tide.py
@@ -623,10 +623,8 @@ def t_tide(xin, dt=1, stime=None, lat=None,
     xoutOLD = xout
     if synth >= 0:
         if lat is not None and stime is not None:
-            # This does not account for latitude,
-            # functionality not added to t_predic yet.
             xout = t_predic(stime + np.array([range(nobs)]) * dt / 24.0,
-                            nameu, fu, tidecon, synth=synth)
+                            nameu, fu, tidecon, synth=synth, lat=lat)
         elif stime is not None:
             xout = t_predic(stime + np.array([range(nobs)]) * dt / 24.0,
                             nameu, fu, tidecon, synth=synth)

--- a/ttide/t_tide.py
+++ b/ttide/t_tide.py
@@ -671,7 +671,7 @@ def t_tide(xin, dt=1, stime=None, lat=None,
             method = 'classic_style'
 
         if outfile:
-            getattr(out, method)(fname=outfile)
+            getattr(out, method)(to_file=outfile)
         else:
             print(getattr(out, method)(), end='')
 

--- a/ttide/t_tide.py
+++ b/ttide/t_tide.py
@@ -381,7 +381,7 @@ def t_tide(xin, dt=1, stime=None, lat=None,
     ####################################################################
     # ---------- Correct for prefiltering--------------------------------
     ####################################################################
-    corrfac = spi.interpolate.interp1d(corr_fs, corr_fac)(fu)
+    corrfac = spi.interp1d(corr_fs, corr_fac)(fu)
     # To stop things blowing up!
     corrfac[corrfac > 100] = 1
     corrfac[corrfac < 0.01] = 1

--- a/ttide/t_tidec.pyx
+++ b/ttide/t_tidec.pyx
@@ -383,7 +383,7 @@ def t_tide(xin, cython.floating dt=1, stime=None, lat=None,
     ####################################################################
     # ---------- Correct for prefiltering--------------------------------
     ####################################################################
-    corrfac = spi.interpolate.interp1d(corr_fs, corr_fac)(fu)
+    corrfac = spi.interp1d(corr_fs, corr_fac)(fu)
     # To stop things blowing up!
     corrfac[corrfac > 100] = 1
     corrfac[corrfac < 0.01] = 1

--- a/ttide/t_vuf.py
+++ b/ttide/t_vuf.py
@@ -98,14 +98,17 @@ def t_vuf(ltype, ctime, ju, lat=None):
 
             # Compute amplitude and phase corrections
             # for shallow water constituents.
+            shallow_m1  = const['ishallow'].astype(int) -1
+            iname_m1    = shallow['iname'].astype(int) -1
+            coefs       = shallow['coef'].astype(np.float64)
+            range_cache = {n:np.arange(n) for n in range(const['nshallow'].max()+1)}
             for k in np.flatnonzero(np.isfinite(const['ishallow'])):
-                ik = ((const['ishallow'][k] - 1 +
-                       np.array(range(0, const['nshallow'][k]))).astype(int))
-                iname = shallow['iname'][ik] - 1
-                coef = shallow['coef'][ik]
-                f[k] = np.prod(np.power(f[iname], coef))
-                u[k] = np.dot(u[iname], coef)
-                v[k] = np.dot(v[iname], coef)
+                ik = shallow_m1[k] + range_cache[const['nshallow'][k]]
+                iname = iname_m1[ik]
+                coef = coefs[ik]
+                f[k] = np.multiply.reduce(np.power(f[iname], coef))
+                u[k] = u[iname].dot(coef)
+                v[k] = v[iname].dot(coef)
 
             f = f[ju]
             u = u[ju]

--- a/ttide/t_vuf.py
+++ b/ttide/t_vuf.py
@@ -48,7 +48,9 @@ def t_vuf(ltype, ctime, ju, lat=None):
         # (This only returns values when we have doodson#s,
         # i.e., not for the shallow water components,
         # but these will be computed later.)
-        v = np.fmod(np.dot(const['doodson'], astro) + const['semi'], 1)
+
+        v = np.dot(const['doodson'], astro) + const['semi']
+        v = np.fmod(v, 1, where=~np.isnan(v))
 
         if lat is not None:
             # If we have a latitude, get nodal corrections.


### PR DESCRIPTION
I pulled changes from the official repository.

* test to quantify the speedup, results are not supposed to change:  
  compute_surge results bitmatch, but the speedup is modest, maybe because we already have it cythonized...
* I still get this warning when running `pytest`, will have to see how to fix it [**Update** this is fixed now as well ]:

```
ttide/tests/predict_test.py::test_predic
  /fs/homeu2/eccc/cmd/cmde/olh001/Python/ttide_py/ttide/t_vuf.py:51: RuntimeWarning: invalid value encountered in fmod
    v = np.fmod(np.dot(const['doodson'], astro) + const['semi'], 1)
```